### PR TITLE
Add Firestore security rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,48 @@
-{"hosting":{"public":"build/web","ignore":["firebase.json","**/.*","**/node_modules/**"],"rewrites":[{"source":"**","destination":"/index.html"}]},"functions":{"predeploy":["npm --prefix \"$RESOURCE_DIR\" run lint","npm --prefix \"$RESOURCE_DIR\" run build"]},"flutter":{"platforms":{"android":{"default":{"projectId":"the-postbox-game","appId":"1:176793005702:android:fbdc8d42630c3ffd","fileOutput":"android/app/google-services.json"}},"dart":{"lib/firebase_options.dart":{"projectId":"the-postbox-game","configurations":{"android":"1:176793005702:android:fbdc8d42630c3ffd","ios":"1:176793005702:ios:471dddd78becfe8c1eab07","macos":"1:176793005702:ios:471dddd78becfe8c1eab07","web":"1:176793005702:web:3be3d668ccca8df91eab07","windows":"1:176793005702:web:d5b26f69d318dc4b1eab07"}}}}}}
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "hosting": {
+    "public": "build/web",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  },
+  "functions": {
+    "predeploy": [
+      "npm --prefix \"$RESOURCE_DIR\" run lint",
+      "npm --prefix \"$RESOURCE_DIR\" run build"
+    ]
+  },
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "the-postbox-game",
+          "appId": "1:176793005702:android:fbdc8d42630c3ffd",
+          "fileOutput": "android/app/google-services.json"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "the-postbox-game",
+          "configurations": {
+            "android": "1:176793005702:android:fbdc8d42630c3ffd",
+            "ios": "1:176793005702:ios:471dddd78becfe8c1eab07",
+            "macos": "1:176793005702:ios:471dddd78becfe8c1eab07",
+            "web": "1:176793005702:web:3be3d668ccca8df91eab07",
+            "windows": "1:176793005702:web:d5b26f69d318dc4b1eab07"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,26 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Postboxes: read-only for authenticated users (ingested by backend/script)
+    match /postboxes/{postboxId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+    // Claims: authenticated users can create; read only own claims
+    match /claims/{claimId} {
+      allow read: if request.auth != null && resource.data.userid == request.auth.uid;
+      allow create: if request.auth != null;
+      allow update, delete: if false;
+    }
+    // User profile/friends: authenticated users can read all; write only own
+    match /users/{userId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+    // Leaderboards: read-only for all (aggregated by backend)
+    match /leaderboards/{period} {
+      allow read: if true;
+      allow write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `firestore.rules` defining read/write rules for `postboxes`, `claims`, `users`, and `leaderboards` collections
- Wires `firestore.rules` into `firebase.json`

## Files changed
- `firestore.rules` — new file
- `firebase.json` — adds `"firestore": { "rules": "firestore.rules" }` alongside existing hosting/functions/flutter config

## Merge notes
No conflicts with any other open PR.

> **Note:** The original branch omitted the `flutter` section of `firebase.json`. This has been corrected — the `flutter` FlutterFire config is preserved alongside the new `firestore` section.