### PR TITLE
Route guard: redirect unauthenticated users to login

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,6 +59,14 @@ class _PostboxGameState extends State<PostboxGame> {
     super.initState();
   }
 
+  /// Redirects to login when accessing protected routes while unauthenticated.
+  Widget _guardRoute(BuildContext context, Widget Function() page) {
+    final state = context.read<AuthenticationBloc>().state;
+    if (state is Authenticated) return page();
+    if (state is Unauthenticated) return LoginScreen(userRepository: _userRepository);
+    return Splash(); // Uninitialized or null
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
@@ -86,8 +94,8 @@ class _PostboxGameState extends State<PostboxGame> {
           routes: {
             '/login': (context) => SignInPage(),
             '/upload': (context) => Upload(),
-            '/nearby': (context) => Nearby(),
-            '/Claim': (context) => Claim(),
+            '/nearby': (context) => _guardRoute(context, () => Nearby()),
+            '/Claim': (context) => _guardRoute(context, () => Claim()),
             '/friends': (context) => const FriendsScreen(),
             '/leaderboard': (context) => const LeaderboardScreen(),
             '/settings': (context) => const SettingsScreen(),


### PR DESCRIPTION
## Summary
- Adds a `_guardRoute()` helper in `_PostboxGameState` that checks `AuthenticationBloc` state
- Wraps the `/nearby` and `/Claim` named routes so unauthenticated deep-links redirect to `LoginScreen`

## Files changed
- `lib/main.dart` — `_guardRoute()` method + updated `/nearby` and `/Claim` route handlers

## Merge notes
⚠️ **Conflicts with `feature/phase4-polish`** (`lib/main.dart`).
If `feature/phase4-polish` merges first, this branch will conflict in the routes block. Resolution: keep `_guardRoute()` wrapping on `/nearby` and `/Claim` from this branch; take the dead-route removal (`/login`, `/upload`) from phase4-polish.