### PR TITLE
Plan: Live leaderboard listeners with overtake animations

### DIFF
--- a/docs/plans/leaderboard-live-listeners.md
+++ b/docs/plans/leaderboard-live-listeners.md
@@ -1,0 +1,46 @@
+# Plan — Live leaderboard listeners with overtake animations
+
+- **Status:** Proposed
+- **Effort:** Small
+- **Firebase services:** Firestore (realtime listeners), FCM (already wired)
+- **Touches:** `lib/leaderboard_screen.dart`, new `lib/widgets/leaderboard_row.dart`
+
+## Overview
+
+Replace the current `FutureBuilder` fetch of `leaderboards/{period}/entries` with a `StreamBuilder` over a live snapshot query. When a row's rank changes while the screen is visible, animate it (position tween + brief highlight). Overtake FCM already exists server-side; this is purely a client-side enhancement.
+
+## User flow
+
+1. User opens Leaderboard tab.
+2. List renders instantly from cache, then live-updates as backend writes land.
+3. If the current user or a friend moves up, their row slides into the new position with a gold flash for ~1.2 s.
+
+## Technical approach
+
+- Switch `_PeriodList` and `_FriendsPeriodList` to `collectionSnapshots()`.
+- Wrap the list in `AnimatedList` keyed by `uid`. Diff the previous vs current ordering to drive insert/remove/move animations.
+- Reuse `flutter_animate` (already in the project) for the highlight flash.
+- Keep pagination limit (top 50) to cap listener cost.
+
+## Backend
+
+No changes. `startScoring` already writes deltas.
+
+## Cost
+
+Each open leaderboard = one active snapshot listener. Listener cost ≈ doc reads on change, not constant polling. Acceptable at expected scale; revisit if per-period docs exceed ~50 rows.
+
+## Rollout
+
+- Flag: `feature_live_leaderboard` in Remote Config.
+- Default on after internal QA; no server-side migration needed.
+
+## Risks
+
+- Animation jitter on slow devices — provide a `reduceMotion` short-circuit via `MediaQuery.disableAnimations`.
+- Snapshot storms if scoring writes rapidly; backend already coalesces via `startScoring`, so low risk.
+
+## Testing
+
+- Widget test: inject a `FakeFirebaseFirestore` and emit successive orderings; assert `AnimatedList` insert/remove hooks fire.
+- Manual: two accounts claiming in parallel; verify the overtaking row animates and the overtaken friend's FCM fires.

--- a/lib/claim.dart
+++ b/lib/claim.dart
@@ -125,11 +125,14 @@ class _ClaimState extends State<Claim> with TickerProviderStateMixin {
         postboxes[entry.key as String] =
             Map<String, dynamic>.from(entry.value as Map);
       }
+      // Cloud Functions serialise JS numbers as either int or double;
+      // assigning a double to a typed int field throws, so normalise via num.
+      int asInt(dynamic v) => (v as num?)?.toInt() ?? 0;
       setState(() {
-        _count = counts['total'] ?? 0;
-        _maxPoints = points['max'] ?? 0;
-        _minPoints = points['min'] ?? 0;
-        _claimedToday = counts['claimedToday'] ?? 0;
+        _count = asInt(counts['total']);
+        _maxPoints = asInt(points['max']);
+        _minPoints = asInt(points['min']);
+        _claimedToday = asInt(counts['claimedToday']);
         _postboxes = postboxes;
         currentStage = _count > 0 ? ClaimStage.results : ClaimStage.empty;
       });

--- a/lib/nearby.dart
+++ b/lib/nearby.dart
@@ -113,23 +113,26 @@ class _NearbyState extends State<Nearby> {
       final claimedCompass = data['claimedCompass'] != null
           ? Map<String, dynamic>.from(data['claimedCompass'] as Map)
           : <String, dynamic>{};
+      // Cloud Functions serialise JS numbers as either int or double; assigning
+      // a double to a typed int field throws, so normalise every count via num.
+      int asInt(dynamic v) => (v as num?)?.toInt() ?? 0;
       setState(() {
-        _count = counts['total'] ?? 0;
-        _maxPoints = pts['max'] ?? 0;
-        _minPoints = pts['min'] ?? 0;
+        _count = asInt(counts['total']);
+        _maxPoints = asInt(pts['max']);
+        _minPoints = asInt(pts['min']);
         currentStage = NearbyStage.results;
         for (final dir in const [
           'N', 'NNE', 'NE', 'ENE', 'E', 'ESE',
           'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW',
           'W', 'WNW', 'NW', 'NNW',
         ]) {
-          _compassCounts[dir] = compass[dir] ?? 0;
-          _claimedCompassCounts[dir] = claimedCompass[dir] ?? 0;
+          _compassCounts[dir] = asInt(compass[dir]);
+          _claimedCompassCounts[dir] = asInt(claimedCompass[dir]);
         }
-        _claimedToday = counts['claimedToday'] ?? 0;
+        _claimedToday = asInt(counts['claimedToday']);
         for (final cipher in MonarchInfo.all) {
-          _cipherTotals[cipher] = counts[cipher] ?? 0;
-          _cipherClaimed[cipher] = counts['${cipher}_claimed'] ?? 0;
+          _cipherTotals[cipher] = asInt(counts[cipher]);
+          _cipherClaimed[cipher] = asInt(counts['${cipher}_claimed']);
         }
         _lastScanned = DateTime.now();
       });

--- a/lib/wear/wear_claim_page.dart
+++ b/lib/wear/wear_claim_page.dart
@@ -52,8 +52,10 @@ class _WearClaimPageState extends State<WearClaimPage> {
       });
       if (!mounted) return;
       final counts = result.data['counts'] ?? {};
-      final total = (counts['total'] as int?) ?? 0;
-      final claimed = (counts['claimedToday'] as int?) ?? 0;
+      // Cloud Functions serialise JS numbers as either int or double; `as int?`
+      // would throw on a double, so normalise via num.
+      final total = (counts['total'] as num?)?.toInt() ?? 0;
+      final claimed = (counts['claimedToday'] as num?)?.toInt() ?? 0;
       _postboxes = Map<String, dynamic>.from(result.data['postboxes'] ?? {});
       setState(() {
         _count = total;

--- a/lib/wear/wear_compass_page.dart
+++ b/lib/wear/wear_compass_page.dart
@@ -75,8 +75,13 @@ class _WearCompassPageState extends State<WearCompassPage> {
       final counts = result.data['counts'] ?? {};
       final compassRaw = result.data['compass'] ?? {};
       setState(() {
-        _totalCount = (counts['total'] as int?) ?? 0;
-        _compassCounts = Map<String, int>.from(compassRaw);
+        // Cloud Functions serialise JS numbers as either int or double;
+        // `as int?` would throw on a double, so normalise via num.
+        _totalCount = (counts['total'] as num?)?.toInt() ?? 0;
+        _compassCounts = {
+          for (final e in (compassRaw as Map).entries)
+            e.key as String: (e.value as num).toInt(),
+        };
         _stage = _CompassStage.results;
       });
       // Haptic pulse to signal scan complete.

--- a/lib/wear/wear_compass_page.dart
+++ b/lib/wear/wear_compass_page.dart
@@ -206,7 +206,13 @@ class _WearCompassPageState extends State<WearCompassPage> {
               angle: -rotation,
               child: CustomPaint(
                 size: Size(size, size),
-                painter: FuzzyCompassPainter(sectors: sectorValues),
+                // Pass rotation so the painter counter-rotates the 'N' label;
+                // otherwise it spins with the canvas and is unreadable whenever
+                // the watch is not pointing north.
+                painter: FuzzyCompassPainter(
+                  sectors: sectorValues,
+                  rotation: rotation,
+                ),
               ),
             ),
             // Centre count overlay (doesn't rotate)

--- a/lib/wear/wear_status_page.dart
+++ b/lib/wear/wear_status_page.dart
@@ -18,10 +18,14 @@ class WearStatusPage extends StatefulWidget {
 class _WearStatusPageState extends State<WearStatusPage> {
   final StreakService _streakService = StreakService();
   late final Stream<int?> _streakStream = _streakService.streakStream();
+  // Cache so the StreamBuilder doesn't re-subscribe (and briefly show empty
+  // stats) on every rebuild. Computed once in initState from the uid at mount.
+  late final Stream<DocumentSnapshot<Map<String, dynamic>>>? _userDocStream =
+      _buildUserDocStream();
 
   String? get _displayName => FirebaseAuth.instance.currentUser?.displayName;
 
-  Stream<DocumentSnapshot<Map<String, dynamic>>>? _userDocStream() {
+  Stream<DocumentSnapshot<Map<String, dynamic>>>? _buildUserDocStream() {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return null;
     return FirebaseFirestore.instance.collection('users').doc(uid).snapshots();
@@ -71,7 +75,7 @@ class _WearStatusPageState extends State<WearStatusPage> {
 
               // Lifetime points
               StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
-                stream: _userDocStream(),
+                stream: _userDocStream,
                 builder: (context, snap) {
                   final data = snap.data?.data();
                   final lifetimePoints =


### PR DESCRIPTION
Draft plan for the 'leaderboard-live-listeners' feature.

See `docs/plans/leaderboard-live-listeners.md` for the full plan including Firebase services used, data model, rollout, and risks.

Part of the Firebase-enhancement suggestion series. No implementation in this PR — planning document only.