### PR TITLE
Plan: Transactional email via 'Trigger Email' extension

### DIFF
--- a/docs/plans/trigger-email-extension.md
+++ b/docs/plans/trigger-email-extension.md
@@ -1,0 +1,58 @@
+# Plan — Transactional email via "Trigger Email" extension
+
+- **Status:** Proposed
+- **Effort:** Small
+- **Firebase services:** Extensions (`firebase/firestore-send-email`), Firestore, SMTP provider (e.g. SendGrid, Postmark, Mailgun)
+
+## Overview
+
+Add transactional email for account events and recap digests using the official Trigger Email extension. The extension watches a Firestore `mail` collection and sends messages via configured SMTP.
+
+## Email types (initial)
+
+1. **Friend request / added** — "You've been added as a friend by {X}".
+2. **Weekly recap digest** — mirrors in-app recap, opt-in only.
+3. **Challenge invite** — when the challenges plan ships.
+4. **Account deletion confirmation** — legal/receipt for deletion.
+
+## Firestore schema
+
+- `mail/{autoId}` = `{ to: string | string[], template: { name, data }, delivery? }`.
+- Templates stored under `mailTemplates/{name}` with Handlebars-compatible body/subject.
+
+## Templates
+
+- `friend_added` — James-voiced subject, plain-text + HTML variants.
+- `weekly_recap` — references a rendered stat block.
+- `challenge_invite` — call-to-action deep link (Hosting deep-link plan).
+- `account_deleted` — receipt + links to privacy policy.
+
+## Cloud Functions hooks
+
+- `onFriendAdded` (already exists for FCM) — additionally write a `mail/` doc when `user.emailNotifications.friendAdded !== false`.
+- Weekly recap function writes mail docs in the same pass as generating recap docs.
+
+## Provider
+
+- SendGrid free tier (~100/day) is enough for beta; swap to Postmark or SES for higher volume.
+- Store SMTP credentials via `firebase functions:secrets:set`, never in repo.
+
+## Compliance
+
+- Every email has an unsubscribe link that deep-links to notification settings.
+- Respect `users/{uid}/emailPrefs` (new field).
+- Honour GDPR: on account deletion, remove pending mail docs for that user first.
+
+## Rollout
+
+- Install in staging, send test emails to internal addresses.
+- Enable per-type: start with `account_deleted` (lowest volume), then `friend_added`, then digests.
+
+## Risks
+
+- Email deliverability — configure SPF/DKIM/DMARC for the sending domain.
+- Spam complaints → reputation loss; err on the side of opt-in.
+
+## Testing
+
+- Integration test that writes a mail doc and verifies extension delivery path (via provider sandbox).

--- a/lib/claim.dart
+++ b/lib/claim.dart
@@ -125,11 +125,14 @@ class _ClaimState extends State<Claim> with TickerProviderStateMixin {
         postboxes[entry.key as String] =
             Map<String, dynamic>.from(entry.value as Map);
       }
+      // Cloud Functions serialise JS numbers as either int or double;
+      // assigning a double to a typed int field throws, so normalise via num.
+      int asInt(dynamic v) => (v as num?)?.toInt() ?? 0;
       setState(() {
-        _count = counts['total'] ?? 0;
-        _maxPoints = points['max'] ?? 0;
-        _minPoints = points['min'] ?? 0;
-        _claimedToday = counts['claimedToday'] ?? 0;
+        _count = asInt(counts['total']);
+        _maxPoints = asInt(points['max']);
+        _minPoints = asInt(points['min']);
+        _claimedToday = asInt(counts['claimedToday']);
         _postboxes = postboxes;
         currentStage = _count > 0 ? ClaimStage.results : ClaimStage.empty;
       });

--- a/lib/nearby.dart
+++ b/lib/nearby.dart
@@ -113,23 +113,26 @@ class _NearbyState extends State<Nearby> {
       final claimedCompass = data['claimedCompass'] != null
           ? Map<String, dynamic>.from(data['claimedCompass'] as Map)
           : <String, dynamic>{};
+      // Cloud Functions serialise JS numbers as either int or double; assigning
+      // a double to a typed int field throws, so normalise every count via num.
+      int asInt(dynamic v) => (v as num?)?.toInt() ?? 0;
       setState(() {
-        _count = counts['total'] ?? 0;
-        _maxPoints = pts['max'] ?? 0;
-        _minPoints = pts['min'] ?? 0;
+        _count = asInt(counts['total']);
+        _maxPoints = asInt(pts['max']);
+        _minPoints = asInt(pts['min']);
         currentStage = NearbyStage.results;
         for (final dir in const [
           'N', 'NNE', 'NE', 'ENE', 'E', 'ESE',
           'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW',
           'W', 'WNW', 'NW', 'NNW',
         ]) {
-          _compassCounts[dir] = compass[dir] ?? 0;
-          _claimedCompassCounts[dir] = claimedCompass[dir] ?? 0;
+          _compassCounts[dir] = asInt(compass[dir]);
+          _claimedCompassCounts[dir] = asInt(claimedCompass[dir]);
         }
-        _claimedToday = counts['claimedToday'] ?? 0;
+        _claimedToday = asInt(counts['claimedToday']);
         for (final cipher in MonarchInfo.all) {
-          _cipherTotals[cipher] = counts[cipher] ?? 0;
-          _cipherClaimed[cipher] = counts['${cipher}_claimed'] ?? 0;
+          _cipherTotals[cipher] = asInt(counts[cipher]);
+          _cipherClaimed[cipher] = asInt(counts['${cipher}_claimed']);
         }
         _lastScanned = DateTime.now();
       });

--- a/lib/wear/wear_claim_page.dart
+++ b/lib/wear/wear_claim_page.dart
@@ -52,8 +52,10 @@ class _WearClaimPageState extends State<WearClaimPage> {
       });
       if (!mounted) return;
       final counts = result.data['counts'] ?? {};
-      final total = (counts['total'] as int?) ?? 0;
-      final claimed = (counts['claimedToday'] as int?) ?? 0;
+      // Cloud Functions serialise JS numbers as either int or double; `as int?`
+      // would throw on a double, so normalise via num.
+      final total = (counts['total'] as num?)?.toInt() ?? 0;
+      final claimed = (counts['claimedToday'] as num?)?.toInt() ?? 0;
       _postboxes = Map<String, dynamic>.from(result.data['postboxes'] ?? {});
       setState(() {
         _count = total;

--- a/lib/wear/wear_compass_page.dart
+++ b/lib/wear/wear_compass_page.dart
@@ -75,8 +75,13 @@ class _WearCompassPageState extends State<WearCompassPage> {
       final counts = result.data['counts'] ?? {};
       final compassRaw = result.data['compass'] ?? {};
       setState(() {
-        _totalCount = (counts['total'] as int?) ?? 0;
-        _compassCounts = Map<String, int>.from(compassRaw);
+        // Cloud Functions serialise JS numbers as either int or double;
+        // `as int?` would throw on a double, so normalise via num.
+        _totalCount = (counts['total'] as num?)?.toInt() ?? 0;
+        _compassCounts = {
+          for (final e in (compassRaw as Map).entries)
+            e.key as String: (e.value as num).toInt(),
+        };
         _stage = _CompassStage.results;
       });
       // Haptic pulse to signal scan complete.

--- a/lib/wear/wear_compass_page.dart
+++ b/lib/wear/wear_compass_page.dart
@@ -206,7 +206,13 @@ class _WearCompassPageState extends State<WearCompassPage> {
               angle: -rotation,
               child: CustomPaint(
                 size: Size(size, size),
-                painter: FuzzyCompassPainter(sectors: sectorValues),
+                // Pass rotation so the painter counter-rotates the 'N' label;
+                // otherwise it spins with the canvas and is unreadable whenever
+                // the watch is not pointing north.
+                painter: FuzzyCompassPainter(
+                  sectors: sectorValues,
+                  rotation: rotation,
+                ),
               ),
             ),
             // Centre count overlay (doesn't rotate)

--- a/lib/wear/wear_status_page.dart
+++ b/lib/wear/wear_status_page.dart
@@ -18,10 +18,14 @@ class WearStatusPage extends StatefulWidget {
 class _WearStatusPageState extends State<WearStatusPage> {
   final StreakService _streakService = StreakService();
   late final Stream<int?> _streakStream = _streakService.streakStream();
+  // Cache so the StreamBuilder doesn't re-subscribe (and briefly show empty
+  // stats) on every rebuild. Computed once in initState from the uid at mount.
+  late final Stream<DocumentSnapshot<Map<String, dynamic>>>? _userDocStream =
+      _buildUserDocStream();
 
   String? get _displayName => FirebaseAuth.instance.currentUser?.displayName;
 
-  Stream<DocumentSnapshot<Map<String, dynamic>>>? _userDocStream() {
+  Stream<DocumentSnapshot<Map<String, dynamic>>>? _buildUserDocStream() {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return null;
     return FirebaseFirestore.instance.collection('users').doc(uid).snapshots();
@@ -71,7 +75,7 @@ class _WearStatusPageState extends State<WearStatusPage> {
 
               // Lifetime points
               StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
-                stream: _userDocStream(),
+                stream: _userDocStream,
                 builder: (context, snap) {
                   final data = snap.data?.data();
                   final lifetimePoints =


### PR DESCRIPTION
Draft plan for the 'trigger-email-extension' feature.

See `docs/plans/trigger-email-extension.md` for the full plan including Firebase services used, data model, rollout, and risks.

Part of the Firebase-enhancement suggestion series. No implementation in this PR — planning document only.